### PR TITLE
Sync ci configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,23 @@ matrix:
     # Because Travis-CI no longer offers the 2.5 environment by default,
     # we'll manually install 2.5.... It's not even available on the common
     # ubuntu repos, so we'll use the well-known deadsnakes repo.
+    #
+    # Also, using ideas from @kura in https://gist.github.com/kura/8517802 ,
+    # download and install a compatible version of easy_install,
+    # which gives us an old version of pip,
+    # which gives us argparse which our unit test framework requires.
     - language: python
       os: linux
       env: Python='2.5' PythonBin="/usr/bin/python2.5"
       install:
         sudo add-apt-repository "ppa:fkrull/deadsnakes" -y;
         sudo apt-get update;
-        sudo apt-get install python2.5;
+        sudo apt-get install python2.5 ;
+        wget https://raw.githubusercontent.com/pypa/setuptools/bootstrap-py24/ez_setup.py -O /tmp/ez_setup.py ;
+        sudo $PythonBin /tmp/ez_setup.py ;
+        sudo easy_install-2.5 pip==1.3.1 ;
+        pip-2.5 --version ;
+        sudo pip-2.5 install --insecure argparse ;
 
     # OS X Instances follow
     # There is no OS X + PYTHON combination available by default, so we

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,4 +84,3 @@ script:
   - $PythonBin build.py -t;
   - cd ../RUNNABLE;
   - $PythonBin utf.py -a;
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,87 @@
+# Travis integration file.
+# Seattle supports Python 2.6 through 2.7, per
+# github.com/SeattleTestbed/docs/blob/master/Contributing/BuildInstructions.md
+# Python 2.5 is included for testing because this is what PlanetLab runs
+#
+# Travis provides OS X and Linux (specifically Ubuntu) OS instances.
+# The result of this configuration will be five separate builds on
+# Travis-CI VMs, 3 python versions on Linux and 2 on OS X.
+
+# Primarily because of some manual fiddling to get python 2.5 tests
+# to work, we require the following directive - we need
+# non-container-based infrastructure so that Travis allows us to use
+# sudo.
+sudo: required
+
+matrix:
+  include:
+    # Linux Instances follow, one for each dash.
+    - language: python          # Language to initiate linux VM
+      python: '2.7'             # Version of python to use
+      os: linux                 # The OS of the VM
+      env: Python='2.7' PythonBin="python" # These are environment variables we'll use.
+        # In particular, PythonBin will specify the location of the python binary to use.
+        # The "Python" env variable there is redundant except for OS X runs below.
+      install:                  # tool installation
+        sudo apt-get update;
+
+    - language: python
+      python: '2.6'
+      os: linux
+      env: Python='2.6' PythonBin="python"
+      install:
+        sudo apt-get update;
+
+    # Because Travis-CI no longer offers the 2.5 environment by default,
+    # we'll manually install 2.5.... It's not even available on the common
+    # ubuntu repos, so we'll use the well-known deadsnakes repo.
+    - language: python
+      os: linux
+      env: Python='2.5' PythonBin="/usr/bin/python2.5"
+      install:
+        sudo add-apt-repository "ppa:fkrull/deadsnakes" -y;
+        sudo apt-get update;
+        sudo apt-get install python2.5;
+
+    # OS X Instances follow
+    # There is no OS X + PYTHON combination available by default, so we
+    # use the "language: generic" directive and we'll install python
+    # ourselves through some install directives.
+    # See references:
+    #   github.com/travis-ci/travis-ci/issues/2312
+    #   docs.travis-ci.com/user/languages/python
+    #   docs.travis-ci.com/user/multi-os/#Python-example-%28unsupported-languages%29
+    # OS X Python current version (currently 2.7.11)
+    - language: generic
+      os: osx
+      env: Python='2.7' PythonBin="python"
+      install:
+          #brew update;
+          brew install python;
+
+    # OS X python 2.6.9
+    # We have to use pyenv to compile and install Python 2.6.9
+    # ourselves for OS X, as Travis-CI offers no OS X Python
+    # environments, and homebrew no longer offers a python26
+    # recipe.
+    - language: generic
+      os: osx
+      env: Python='2.6.9' PythonBin="/Users/travis/.pyenv/versions/2.6.9/bin/python" TERM='linux'
+      install:
+        #brew update;
+        #brew install python26; # This is no longer available.
+        pyenv install 2.6.9;
+        pyenv global 2.6.9;
+
+# These are the commands we'll run for each build, posting the python
+# version we're *really* running, initializing to obtain needed common
+# seattle projects, building the current seattle project, and running
+# the seattle unit testing framework, with all tests.
+script:
+  - $PythonBin --version;
+  - cd ./scripts;
+  - $PythonBin initialize.py;
+  - $PythonBin build.py -t;
+  - cd ../RUNNABLE;
+  - $PythonBin utf.py -a;
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,59 @@
+# Seattle supports Python 2.6 through 2.7, per
+# github.com/SeattleTestbed/docs/blob/master/Contributing/BuildInstructions.md
+# Python 2.5 is included for testing because this is what PlanetLab runs
+#
+# AppVeyor provides Windows-based testing.
+# On Windows, we currently test on Python 2.6 and 2.7.
+# The result of the current configuration should be 4 runs:
+#   32bit platform, Python 2.6
+#   64bit platform, Python 2.6
+#   32bit platform, Python 2.7
+#   64bit platform, Python 2.7
+
+build: false
+
+# Default OS is Windows Server 2012 R2
+# As an example, uncommenting the 3 lines below would
+# result in builds being run both on the current version
+# of Windows Server 2012 R2 and the previous version of
+# Windows Server 2012 R2.
+#os:
+#  - Previous Windows Server 2012 R2
+#  - Windows Server 2012 R2
+
+environment:
+  matrix:
+    # Run on each of the following two Python setups.
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+
+    - PYTHON: "C:\\Python26"
+      PYTHON_VERSION: "2.6.x"
+
+    # AppVeyor no longer supports Python 2.5 by default. If necessary, we can
+    # try to figure out how to get it running, but it is not currently a
+    # priority.
+    #- PYTHON: "C:\\Python25"
+    #  PYTHON_VERSION: "2.5.x"
+
+# Run each on 32-bit and 64-bit platforms.
+platform:
+  - x86
+  - x64
+
+# These are the commands we'll run for each build, posting the python
+# version we're *really* running, initializing to obtain needed common
+# seattle projects, building the current seattle project, and ...
+build_script:
+  - "%PYTHON%\\python --version"
+  - "cd scripts"
+  - "%PYTHON%\\python initialize.py"
+  - "%PYTHON%\\python build.py -t"
+
+# ... running the seattle unit testing framework, with all tests.
+test_script:
+  - "cd ../RUNNABLE"
+  - "%PYTHON%\\python utf.py -a"
+
+skip_commits:
+  message: /(Update README*|Created.*\.(png|jpg|jpeg|bmp|gif))/


### PR DESCRIPTION
Manually syncs most recent AppVeyor and Travis-CI config files from central  [continuous integration repo](https://github.com/SeattleTestbed/continuous-integration), which also provides more information on how to use CI.

Btw. this push already triggered testing. Results will be shown here:
- [AppVeyor results](https://ci.appveyor.com/project/lukpueh/experimentmanager)
- [Travis-CI results](https://travis-ci.org/lukpueh/experimentmanager)
